### PR TITLE
Small fixes oct

### DIFF
--- a/fusion/fusion.py
+++ b/fusion/fusion.py
@@ -606,7 +606,7 @@ class Fusion:
 
         valid_date_range = re.compile(r"^(\d{4}\d{2}\d{2})$|^((\d{4}\d{2}\d{2})?([:])(\d{4}\d{2}\d{2})?)$")
 
-        if valid_date_range.match(dt_str):
+        if valid_date_range.match(dt_str) or dt_str == 'latest':
             required_series = self._resolve_distro_tuples(
                 dataset, dt_str, dataset_format, catalog
             )

--- a/fusion/fusion.py
+++ b/fusion/fusion.py
@@ -601,10 +601,18 @@ class Fusion:
         """
         catalog = self.__use_catalog(catalog)
 
+       
+
         n_par = cpu_count(n_par)
-        required_series = self._resolve_distro_tuples(
-            dataset, dt_str, dataset_format, catalog
-        )
+
+        #sample data is limited to csv
+        if dt_str == 'sample':
+            dataset_format = 'csv'
+            required_series = [(catalog, dataset, dt_str, dataset_format)]
+        else:
+            required_series = self._resolve_distro_tuples(
+                dataset, dt_str, dataset_format, catalog
+            )
 
         if not download_folder:
             download_folder = self.download_folder
@@ -702,6 +710,10 @@ class Fusion:
                 If multiple dataset instances are retrieved then these are concatenated first.
         """
         catalog = self.__use_catalog(catalog)
+
+        #sample data is limited to csv
+        if dt_str == 'sample':
+            dataset_format = 'csv'
 
         n_par = cpu_count(n_par)
         if not download_folder:

--- a/fusion/fusion.py
+++ b/fusion/fusion.py
@@ -275,9 +275,9 @@ class Fusion:
         df["category"] = df.category.str.join(", ")
         df["region"] = df.region.str.join(", ")
         if not display_all_columns:
-            df = df[
+            df = df[df.columns.intersection(
                 ["identifier", "title", "region", "category", "status", "description"]
-            ]
+            )]
 
         if max_results > -1:
             df = df[0:max_results]
@@ -416,7 +416,7 @@ class Fusion:
         )
 
         if not display_all_columns:
-            df = df[["identifier", "title", "dataType", "isDatasetKey", "description", "source"]]
+            df = df[df.columns.intersection(["identifier", "title", "dataType", "isDatasetKey", "description", "source"])]
 
         if output:
             print(tabulate(df, headers="keys", tablefmt="psql", maxcolwidths=30))

--- a/fusion/fusion.py
+++ b/fusion/fusion.py
@@ -13,6 +13,7 @@ from joblib import Parallel, delayed
 from tabulate import tabulate
 from tqdm import tqdm
 import pyarrow as pa
+import re
 
 from .authentication import FusionCredentials, get_default_fs
 from .exceptions import APIResponseError
@@ -601,18 +602,20 @@ class Fusion:
         """
         catalog = self.__use_catalog(catalog)
 
-       
-
         n_par = cpu_count(n_par)
 
-        #sample data is limited to csv
-        if dt_str == 'sample':
-            dataset_format = 'csv'
-            required_series = [(catalog, dataset, dt_str, dataset_format)]
-        else:
+        valid_date_range = re.compile(r"^(\d{4}\d{2}\d{2})$|^((\d{4}\d{2}\d{2})?([:])(\d{4}\d{2}\d{2})?)$")
+
+        if valid_date_range.match(dt_str):
             required_series = self._resolve_distro_tuples(
                 dataset, dt_str, dataset_format, catalog
             )
+        else:
+            #sample data is limited to csv
+            if dt_str == 'sample':
+                dataset_format = 'csv'
+            required_series = [(catalog, dataset, dt_str, dataset_format)]
+
 
         if not download_folder:
             download_folder = self.download_folder

--- a/fusion/utils.py
+++ b/fusion/utils.py
@@ -51,6 +51,7 @@ from .authentication import FusionCredentials, FusionOAuthAdapter, FusionAiohttp
 logger = logging.getLogger(__name__)
 VERBOSE_LVL = 25
 DT_YYYYMMDD_RE = re.compile(r"^(\d{4})(\d{2})(\d{2})$")
+DT_YYYYMMDDTHHMM_RE = re.compile(r"(\d{4})(\d{2})(\d{2})T(\d{4})$")
 DT_YYYY_MM_DD_RE = re.compile(r"^(\d{4})-(\d{1,2})-(\d{1,2})$")
 DEFAULT_CHUNK_SIZE = 2 ** 16
 DEFAULT_THREAD_POOL_SIZE = 5
@@ -333,6 +334,11 @@ def _normalise_dt_param(dt: Union[str, int, datetime.datetime, datetime.date]) -
         return f"{yr}-{mth}-{day}"
 
     matches = DT_YYYYMMDD_RE.match(dt)
+
+    if matches:
+        return "-".join(matches.groups())
+    
+    matches = DT_YYYYMMDDTHHMM_RE.match(dt)
 
     if matches:
         return "-".join(matches.groups())

--- a/fusion/utils.py
+++ b/fusion/utils.py
@@ -430,7 +430,10 @@ def distribution_to_url(
     if datasetseries[-1] == "/" or datasetseries[-1] == "\\":
         datasetseries = datasetseries[0:-1]
 
-    return f"{root_url}catalogs/{catalog}/datasets/{dataset}/datasetseries/{datasetseries}/distributions/{file_format}"
+    if datasetseries == 'sample':
+        return f"{root_url}catalogs/{catalog}/datasets/{dataset}/sample/distributions/csv"
+    else:
+        return f"{root_url}catalogs/{catalog}/datasets/{dataset}/datasetseries/{datasetseries}/distributions/{file_format}"
 
 
 def _get_canonical_root_url(any_url: str) -> str:


### PR DESCRIPTION
Support for sample file download and fix to handle filtering down the default attributes for datasets and products (to handle if there are missing values in which case the attribute is missing from the response), and handle non-date based series member identifiers (e.g. datetime or label) without affecting current behaviour, including the latest label.