### PR TITLE
eliminate dependency on async-retrying

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ tqdm = ">=4.64.0"
 pyarrow = ">=11.0"
 fsspec = ">=2021.6.1"
 aiohttp = ">=3.7.1"
-async-retrying = "^0.2"
 
 polars = { version = ">=0.12", optional = true }
 markupsafe = { version = ">=2.0.1", optional = true }

--- a/pyproject_docs_build.toml
+++ b/pyproject_docs_build.toml
@@ -37,7 +37,6 @@ tqdm = ">=4.64.0"
 pyarrow = ">=11.0"
 fsspec = ">=2021.6.1"
 aiohttp = ">=3.7.1"
-async-retrying = "^0.2"
 
 polars = { version = ">=0.12", optional = true }
 markupsafe = { version = ">=2.0.1", optional = true }


### PR DESCRIPTION
Eliminate dependency on async-retrying package which breaks with python 3.10+