### PR TITLE
multipart/range-request download if only 1 file is downloaded

### DIFF
--- a/fusion/fusion.py
+++ b/fusion/fusion.py
@@ -694,7 +694,7 @@ class Fusion:
                 self.fs.mkdir(d, create_parents=True)
 
         if len(required_series) == 1:
-            with tqdm(total=1) as _:
+            with tqdm(total=1) as pbar:
                 res = download_single_file_threading(
                     self.credentials,
                     distribution_to_url(
@@ -714,6 +714,7 @@ class Fusion:
                     ),
                     fs=self.fs,
                 )
+                pbar.update(1)
 
         else:
             download_spec = [

--- a/fusion/fusion.py
+++ b/fusion/fusion.py
@@ -714,7 +714,8 @@ class Fusion:
                     ),
                     fs=self.fs,
                 )
-                pbar.update(1)
+                if (len(res) > 0) and all((r[0] for r in res)):
+                    pbar.update(1)
 
         else:
             download_spec = [

--- a/fusion/utils.py
+++ b/fusion/utils.py
@@ -748,6 +748,8 @@ def stream_single_file_new_session_chunks(
         start (int): Start byte.
         end(int): End byte.
         lock (Threading.Lock): Lock.
+        results (list): Results list.
+        idx (int): Results list index.
         overwrite (bool, optional): True if previously downloaded files should be overwritten. Defaults to True.
         fs (fsspec.filesystem): Filesystem.
 
@@ -791,7 +793,7 @@ def download_single_file_threading(
     chunk_size: int = 5 * 2**20,
     fs: fsspec.AbstractFileSystem = fsspec.filesystem("file"),
 ):
-    """
+    """Download single file using range requests.
 
     Args:
         credentials (FusionCredentials): Valid user credentials to provide an access token

--- a/fusion/utils.py
+++ b/fusion/utils.py
@@ -517,7 +517,10 @@ def distribution_to_url(
             f"{root_url}catalogs/{catalog}/datasets/{dataset}/sample/distributions/csv"
         )
 
-    return f"{root_url}catalogs/{catalog}/datasets/{dataset}/datasetseries/{datasetseries}/distributions/{file_format}/operationType/download"
+    return (
+        f"{root_url}catalogs/{catalog}/datasets/{dataset}/datasetseries/"
+        f"{datasetseries}/distributions/{file_format}/operationType/download"
+    )
 
 
 def _get_canonical_root_url(any_url: str) -> str:

--- a/fusion/utils.py
+++ b/fusion/utils.py
@@ -769,14 +769,13 @@ def stream_single_file_new_session_chunks(
         url = url + f"?downloadRange=bytes={start}-{end-1}"
         with get_session(credentials, url).get(url, stream=False) as r:
             r.raise_for_status()
-            byte_cnt = 0
             with lock:
                 output_file.seek(start)
                 output_file.write(r.content)
 
         logger.log(
             VERBOSE_LVL,
-            f"Wrote {byte_cnt:,} bytes to {output_file}",
+            f"Wrote {start} - {end} bytes to {output_file}",
         )
         results[idx] = (True, output_file, None)
         return 0

--- a/fusion/utils.py
+++ b/fusion/utils.py
@@ -9,9 +9,12 @@ import re
 import sys
 from datetime import timedelta
 from io import BytesIO
+import math
 from pathlib import Path
 from typing import Union
 from urllib.parse import urlparse, urlunparse
+from threading import Thread
+from threading import Lock
 
 import aiohttp
 import joblib
@@ -514,7 +517,7 @@ def distribution_to_url(
             f"{root_url}catalogs/{catalog}/datasets/{dataset}/sample/distributions/csv"
         )
 
-    return f"{root_url}catalogs/{catalog}/datasets/{dataset}/datasetseries/{datasetseries}/distributions/{file_format}"
+    return f"{root_url}catalogs/{catalog}/datasets/{dataset}/datasetseries/{datasetseries}/distributions/{file_format}/operationType/download"
 
 
 def _get_canonical_root_url(any_url: str) -> str:
@@ -724,6 +727,106 @@ def _stream_single_file_new_session_dry_run(credentials, url: str, output_file: 
         return False, output_file, ex
 
 
+def stream_single_file_new_session_chunks(
+    credentials,
+    url: str,
+    output_file: str,
+    start: int,
+    end: int,
+    lock,
+    results: list,
+    idx: int,
+    overwrite: bool = True,
+    fs: fsspec.AbstractFileSystem = fsspec.filesystem("file"),
+) -> tuple:
+    """Function to stream a single file from the API to a file on disk.
+
+    Args:
+        credentials (FusionCredentials): Valid user credentials to provide an acces token
+        url (str): The URL to call.
+        output_file (str): The file handle for the target write file.
+        start (int): Start byte.
+        end(int): End byte.
+        lock (Threading.Lock): Lock.
+        overwrite (bool, optional): True if previously downloaded files should be overwritten. Defaults to True.
+        fs (fsspec.filesystem): Filesystem.
+
+    Returns:
+        tuple: A tuple
+
+    """
+
+    if not overwrite and fs.exists(output_file):
+        return True, output_file, None
+
+    try:
+        url = url + f"?downloadRange=bytes={start}-{end-1}"
+        with get_session(credentials, url).get(url, stream=False) as r:
+            r.raise_for_status()
+            byte_cnt = 0
+            with lock:
+                # with fs.open(output_file, "wb") as outfile:
+                # outfile.seek(start)
+                # outfile.write(r.content)
+                output_file.seek(start)
+                output_file.write(r.content)
+
+        logger.log(
+            VERBOSE_LVL,
+            f"Wrote {byte_cnt:,} bytes to {output_file}",
+        )
+        results[idx] = (True, output_file, None)
+    except Exception as ex:
+        logger.log(
+            VERBOSE_LVL,
+            f"Failed to write to {output_file}. ex - {ex}",
+        )
+        results[idx] = (False, output_file, ex)
+
+
+def download_single_file_threading(
+    credentials,
+    url: str,
+    output_file,
+    chunk_size: int = 5 * 2**20,
+    fs: fsspec.AbstractFileSystem = fsspec.filesystem("file"),
+):
+    """
+
+    Args:
+        credentials (FusionCredentials): Valid user credentials to provide an access token
+        url (str): The URL to call.
+        output_file (str): The filename that the data will be saved into.
+        chunk_size (int): Chunk size for parallelization.
+        fs (fsspec.filesystem): Filesystem.
+
+    Returns: List[Tuple]
+
+    """
+    header = get_session(credentials, url).head(url).headers
+    content_length = int(header["Content-Length"])
+    n_chunks = int(math.ceil(content_length / chunk_size))
+    starts = [i * chunk_size for i in range(n_chunks)]
+    ends = [min((i + 1) * chunk_size, content_length) for i in range(n_chunks)]
+    lock = Lock()
+    output_file = fs.open(output_file, "wb")
+    results = [None] * n_chunks
+    threads = [
+        Thread(
+            target=stream_single_file_new_session_chunks,
+            args=(credentials, url, output_file, start, end, lock, results, idx),
+        )
+        for idx, (start, end) in enumerate(zip(starts, ends))
+    ]
+    for thread in threads:
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+    output_file.close()
+    return results
+
+
 def stream_single_file_new_session(
     credentials,
     url: str,
@@ -736,7 +839,7 @@ def stream_single_file_new_session(
     """Function to stream a single file from the API to a file on disk.
 
     Args:
-        credentials (FusionCredentials): Valid user credentials to provide an acces token
+        credentials (FusionCredentials): Valid user credentials to provide an access token
         url (str): The URL to call.
         output_file (str): The filename that the data will be saved into.
         overwrite (bool, optional): True if previously downloaded files should be overwritten. Defaults to True.


### PR DESCRIPTION
* Right now it only is triggered if the user downloads 1 file only using .download method of Fusion
* Next phase is to
   *  implement multi-part for fusion filesystem
   * rationalize multipart download based on the number of parts the files has
   * rationalize the choice when to parallelize over all files and when over a single file