### PR TITLE
Enable Jinja2 Autoescape

### DIFF
--- a/py_tests/bench_rep_gen.py
+++ b/py_tests/bench_rep_gen.py
@@ -65,7 +65,7 @@ def py_bench(py_vers: Annotated[str, PyVerOpt]) -> None:
             if fullname in curr_map and benchmark["options"] == curr_map[fullname]["options"]:
                 curr_map[fullname]["prev_stats"] = benchmark["stats"]
 
-        env = Environment(loader=FileSystemLoader("."))
+        env = Environment(loader=FileSystemLoader("."), autoescape=True)
         template = env.get_template("py_tests/bench_template.html")
 
         print(curr_data)


### PR DESCRIPTION
This codemod enables autoescaping of HTML content in `jinja2`. Unfortunately, the jinja2 default behavior is to not autoescape when rendering templates, which makes your applications potentially vulnerable to Cross-Site Scripting (XSS) attacks.

Our codemod checks if you forgot to enable autoescape or if you explicitly disabled it. The change looks as follows:

```diff
  from jinja2 import Environment

- env = Environment()
- env = Environment(autoescape=False, loader=some_loader)
+ env = Environment(autoescape=True)
+ env = Environment(autoescape=True, loader=some_loader)
  ...
```

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/attacks/xss/](https://owasp.org/www-community/attacks/xss/)
  * [https://jinja.palletsprojects.com/en/3.1.x/api/#autoescaping](https://jinja.palletsprojects.com/en/3.1.x/api/#autoescaping)
</details>

I have additional improvements ready for this repo! If you want to see them, install our plugin (Github Marketplace [download](https://github.com/apps/pixeebot)) & leave the comment:
```
@pixeebot next
```
... and I will open a new PR right away!


🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: pixee:python/enable-jinja2-autoescape ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fjpmorganchase_fusion%7C2b4288b01cf3c1ef135c7ccf0a382d7e175024e3)


<!--{"type":"DRIP","codemod":"pixee:python/enable-jinja2-autoescape"}-->