### PR TITLE
Reduce licensing service calls and enhance bulk upload feature

### DIFF
--- a/py_src/fusion/__init__.py
+++ b/py_src/fusion/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Fusion Devs"""
 __email__ = "fusion_developers@jpmorgan.com"
-__version__ = "2.0.13"
+__version__ = "2.0.14-dev0"
 
 from fusion._fusion import FusionCredentials
 from fusion.fs_sync import fsync

--- a/py_src/fusion/fs_sync.py
+++ b/py_src/fusion/fs_sync.py
@@ -156,7 +156,7 @@ def _get_local_state(
 
         local_files_temp = fs_local.find(local_dir)
         local_rel_path = [i[i.find(local_dir) :] for i in local_files_temp]
-        local_file_validation = validate_file_names(local_rel_path, fs_fusion)
+        local_file_validation = validate_file_names(local_rel_path)
         local_files += [f for flag, f in zip(local_file_validation, local_files_temp) if flag]
         local_files_rel += [
             Path(local_dir, relpath(loc_file, local_dir).replace("\\", "/").replace(local_path, ""))

--- a/py_src/fusion/fs_sync.py
+++ b/py_src/fusion/fs_sync.py
@@ -21,7 +21,6 @@ from .utils import (
     is_dataset_raw,
     path_to_url,
     upload_files,
-    validate_file_names,
 )
 
 logger = logging.getLogger(__name__)
@@ -155,9 +154,7 @@ def _get_local_state(
             fs_local.mkdir(local_dir, exist_ok=True, create_parents=True)
 
         local_files_temp = fs_local.find(local_dir)
-        local_rel_path = [i[i.find(local_dir) :] for i in local_files_temp]
-        local_file_validation = validate_file_names(local_rel_path, fs_fusion)
-        local_files += [f for flag, f in zip(local_file_validation, local_files_temp) if flag]
+        local_files += local_files_temp
         local_files_rel += [
             Path(local_dir, relpath(loc_file, local_dir).replace("\\", "/").replace(local_path, ""))
             for loc_file in local_files_temp

--- a/py_src/fusion/fs_sync.py
+++ b/py_src/fusion/fs_sync.py
@@ -21,6 +21,7 @@ from .utils import (
     is_dataset_raw,
     path_to_url,
     upload_files,
+    validate_file_names,
 )
 
 logger = logging.getLogger(__name__)
@@ -154,7 +155,9 @@ def _get_local_state(
             fs_local.mkdir(local_dir, exist_ok=True, create_parents=True)
 
         local_files_temp = fs_local.find(local_dir)
-        local_files += local_files_temp
+        local_rel_path = [i[i.find(local_dir) :] for i in local_files_temp]
+        local_file_validation = validate_file_names(local_rel_path, fs_fusion)
+        local_files += [f for flag, f in zip(local_file_validation, local_files_temp) if flag]
         local_files_rel += [
             Path(local_dir, relpath(loc_file, local_dir).replace("\\", "/").replace(local_path, ""))
             for loc_file in local_files_temp

--- a/py_src/fusion/fusion.py
+++ b/py_src/fusion/fusion.py
@@ -47,7 +47,6 @@ from .utils import (
     read_parquet,
     requests_raise_for_status,
     upload_files,
-    validate_file_names,
 )
 
 if TYPE_CHECKING:
@@ -1231,16 +1230,12 @@ class Fusion:
         fs_fusion = self.get_fusion_filesystem()
         if self.fs.info(path)["type"] == "directory":
             file_path_lst = self.fs.find(path)
-            local_file_validation = validate_file_names(file_path_lst, fs_fusion)
-            file_path_lst = [f for flag, f in zip(local_file_validation, file_path_lst) if flag]
             file_name = [f.split("/")[-1] for f in file_path_lst]
             is_raw_lst = is_dataset_raw(file_path_lst, fs_fusion)
             local_url_eqiv = [path_to_url(i, r) for i, r in zip(file_path_lst, is_raw_lst)]
         else:
             file_path_lst = [path]
             if not catalog or not dataset:
-                local_file_validation = validate_file_names(file_path_lst, fs_fusion)
-                file_path_lst = [f for flag, f in zip(local_file_validation, file_path_lst) if flag]
                 is_raw_lst = is_dataset_raw(file_path_lst, fs_fusion)
                 local_url_eqiv = [path_to_url(i, r) for i, r in zip(file_path_lst, is_raw_lst)]
                 if preserve_original_name:

--- a/py_src/fusion/fusion.py
+++ b/py_src/fusion/fusion.py
@@ -35,6 +35,7 @@ from .utils import (
     csv_to_table,
     distribution_to_filename,
     distribution_to_url,
+    file_name_to_url,
     get_default_fs,
     get_session,
     is_dataset_raw,
@@ -47,6 +48,7 @@ from .utils import (
     read_parquet,
     requests_raise_for_status,
     upload_files,
+    validate_file_formats,
     validate_file_names,
 )
 
@@ -1199,8 +1201,8 @@ class Fusion:
         """Uploads the requested files/files to Fusion.
 
         Args:
-            path (str): path to a file or a folder with files
-            dataset (str, optional): Dataset identifier to which the file will be uploaded (for single file only).
+            path (str): path to a file or a folder with sub folders and files
+            dataset (str, optional): Dataset identifier to which the files will be uploaded.
                                     If not provided the dataset will be implied from file's name.
             dt_str (str, optional): A file name. Can be any string but is usually a date.
                                     Defaults to 'latest' which will return the most recent.
@@ -1227,15 +1229,44 @@ class Fusion:
 
         if not self.fs.exists(path):
             raise RuntimeError("The provided path does not exist")
+        
+        # Normalize the dt_str
+        date_identifier = re.compile(r"^(\d{4})(\d{2})(\d{2})$")
+        if dt_str == "latest":
+            dt_str = pd.Timestamp("today").date().strftime("%Y%m%d")
+        elif date_identifier.match(dt_str):
+            dt_str = pd.Timestamp(dt_str).date().strftime("%Y%m%d")
+        else:
+            raise ValueError(f"Invalid date format: {dt_str}. Expected YYYYMMDD or 'latest'.")
 
         fs_fusion = self.get_fusion_filesystem()
         if self.fs.info(path)["type"] == "directory":
-            file_path_lst = self.fs.find(path)
-            local_file_validation = validate_file_names(file_path_lst)
-            file_path_lst = [f for flag, f in zip(local_file_validation, file_path_lst) if flag]
-            file_name = [f.split("/")[-1] for f in file_path_lst]
-            is_raw_lst = is_dataset_raw(file_path_lst, fs_fusion)
-            local_url_eqiv = [path_to_url(i, r) for i, r in zip(file_path_lst, is_raw_lst)]
+            validate_file_formats(self.fs, path)
+            file_path_lst = [f for f in self.fs.find(path) if self.fs.info(f)["type"] == "file"]
+
+            # Construct unique file names by flattening the relative path from the base directory.
+            # For example, if the base directory is 'data_folder' and a file is at 'data_folder/sub1/file.txt',
+            # the resulting name will be 'data_folder__sub1__file.txt'.
+            # This ensures that files in different subdirectories with the same base name do not conflict
+            # and helps preserve the folder structure in the filename.  
+            file_name = [
+                Path(path).name + "__" + "__".join(Path(f).relative_to(path).parts)
+                for f in file_path_lst
+            ]
+
+            if catalog and dataset:
+                # Construct URL mappings using the constructed file names as the series member
+                local_url_eqiv = [
+                    file_name_to_url(fname, dataset, catalog, is_download=False)
+                    for fname in file_name
+                ]
+            else:
+                # No catalog/dataset: validate file names and infer raw
+                local_file_validation = validate_file_names(file_path_lst)
+                file_path_lst = [f for flag, f in zip(local_file_validation, file_path_lst) if flag]
+                file_name = [f.split("/")[-1] for f in file_path_lst]
+                is_raw_lst = is_dataset_raw(file_path_lst, fs_fusion)
+                local_url_eqiv = [path_to_url(i, r) for i, r in zip(file_path_lst, is_raw_lst)]
         else:
             file_path_lst = [path]
             if not catalog or not dataset:
@@ -1246,11 +1277,6 @@ class Fusion:
                 if preserve_original_name:
                     raise ValueError("preserve_original_name can only be used when catalog and dataset are provided.")
             else:
-                date_identifier = re.compile(r"^(\d{4})(\d{2})(\d{2})$")
-                if date_identifier.match(dt_str):
-                    dt_str = dt_str if dt_str != "latest" else pd.Timestamp("today").date().strftime("%Y%m%d")
-                    dt_str = pd.Timestamp(dt_str).date().strftime("%Y%m%d")                
-                
                 file_format = path.split(".")[-1]
                 file_name = [path.split("/")[-1]]
                 file_format = "raw" if file_format not in RECOGNIZED_FORMATS else file_format
@@ -1259,12 +1285,12 @@ class Fusion:
                     "/".join(distribution_to_url("", dataset, dt_str, file_format, catalog, False).split("/")[1:])
                 ]
 
-        if not preserve_original_name:
-            data_map_df = pd.DataFrame([file_path_lst, local_url_eqiv]).T
-            data_map_df.columns = pd.Index(["path", "url"])
-        else:
+        if self.fs.info(path)["type"] == "directory" or preserve_original_name:
             data_map_df = pd.DataFrame([file_path_lst, local_url_eqiv, file_name]).T
             data_map_df.columns = pd.Index(["path", "url", "file_name"])
+        else:
+            data_map_df = pd.DataFrame([file_path_lst, local_url_eqiv]).T
+            data_map_df.columns = pd.Index(["path", "url"])
 
         n_par = cpu_count(n_par)
         res = upload_files(

--- a/py_src/fusion/fusion.py
+++ b/py_src/fusion/fusion.py
@@ -1249,28 +1249,8 @@ class Fusion:
                 date_identifier = re.compile(r"^(\d{4})(\d{2})(\d{2})$")
                 if date_identifier.match(dt_str):
                     dt_str = dt_str if dt_str != "latest" else pd.Timestamp("today").date().strftime("%Y%m%d")
-                    dt_str = pd.Timestamp(dt_str).date().strftime("%Y%m%d")
-
-                try:
-                    catalog_list = fs_fusion.ls(catalog)
-                except FileNotFoundError:
-                    raise RuntimeError(f"The catalog '{catalog}' does not exist.") from None
-
-                try:
-                    if (
-                        catalog not in [i.split("/")[0] for i in catalog_list]
-                        or not js.loads(fs_fusion.cat(f"{catalog}/datasets/{dataset}"))["identifier"]
-                    ):
-                        msg = (
-                            f"File file has not been uploaded, one of the catalog: {catalog} "
-                            f"or dataset: {dataset} does not exist."
-                        )
-                        warnings.warn(msg, stacklevel=2)
-                        return [(False, path, msg)]
-                except Exception as e:  # noqa: BLE001
-                    msg = f"An error occurred while checking the dataset: {str(e)}"
-                    warnings.warn(msg, stacklevel=2)
-                    return [(False, path, msg)]
+                    dt_str = pd.Timestamp(dt_str).date().strftime("%Y%m%d")                
+                
                 file_format = path.split(".")[-1]
                 file_name = [path.split("/")[-1]]
                 file_format = "raw" if file_format not in RECOGNIZED_FORMATS else file_format

--- a/py_src/fusion/fusion.py
+++ b/py_src/fusion/fusion.py
@@ -1239,13 +1239,14 @@ class Fusion:
 
             file_path_lst = [f for f in self.fs.find(path) if self.fs.info(f)["type"] == "file"]
 
+            base_path = Path(path).resolve()
             # Construct unique file names by flattening the relative path from the base directory.
             # For example, if the base directory is 'data_folder' and a file is at 'data_folder/sub1/file.txt',
             # the resulting name will be 'data_folder__sub1__file.txt'.
             # This ensures that files in different subdirectories with the same base name do not conflict
             # and helps preserve the folder structure in the filename.  
             file_name = [
-                Path(path).name + "__" + "__".join(Path(f).relative_to(path).parts)
+                base_path.name + "__" + "__".join(Path(f).resolve().relative_to(base_path).parts)
                 for f in file_path_lst
             ]
 

--- a/py_src/fusion/fusion.py
+++ b/py_src/fusion/fusion.py
@@ -1231,7 +1231,7 @@ class Fusion:
         fs_fusion = self.get_fusion_filesystem()
         if self.fs.info(path)["type"] == "directory":
             file_path_lst = self.fs.find(path)
-            local_file_validation = validate_file_names(file_path_lst, fs_fusion)
+            local_file_validation = validate_file_names(file_path_lst)
             file_path_lst = [f for flag, f in zip(local_file_validation, file_path_lst) if flag]
             file_name = [f.split("/")[-1] for f in file_path_lst]
             is_raw_lst = is_dataset_raw(file_path_lst, fs_fusion)
@@ -1239,7 +1239,7 @@ class Fusion:
         else:
             file_path_lst = [path]
             if not catalog or not dataset:
-                local_file_validation = validate_file_names(file_path_lst, fs_fusion)
+                local_file_validation = validate_file_names(file_path_lst)
                 file_path_lst = [f for flag, f in zip(local_file_validation, file_path_lst) if flag]
                 is_raw_lst = is_dataset_raw(file_path_lst, fs_fusion)
                 local_url_eqiv = [path_to_url(i, r) for i, r in zip(file_path_lst, is_raw_lst)]

--- a/py_src/fusion/fusion.py
+++ b/py_src/fusion/fusion.py
@@ -47,6 +47,7 @@ from .utils import (
     read_parquet,
     requests_raise_for_status,
     upload_files,
+    validate_file_names,
 )
 
 if TYPE_CHECKING:
@@ -1230,12 +1231,16 @@ class Fusion:
         fs_fusion = self.get_fusion_filesystem()
         if self.fs.info(path)["type"] == "directory":
             file_path_lst = self.fs.find(path)
+            local_file_validation = validate_file_names(file_path_lst, fs_fusion)
+            file_path_lst = [f for flag, f in zip(local_file_validation, file_path_lst) if flag]
             file_name = [f.split("/")[-1] for f in file_path_lst]
             is_raw_lst = is_dataset_raw(file_path_lst, fs_fusion)
             local_url_eqiv = [path_to_url(i, r) for i, r in zip(file_path_lst, is_raw_lst)]
         else:
             file_path_lst = [path]
             if not catalog or not dataset:
+                local_file_validation = validate_file_names(file_path_lst, fs_fusion)
+                file_path_lst = [f for flag, f in zip(local_file_validation, file_path_lst) if flag]
                 is_raw_lst = is_dataset_raw(file_path_lst, fs_fusion)
                 local_url_eqiv = [path_to_url(i, r) for i, r in zip(file_path_lst, is_raw_lst)]
                 if preserve_original_name:

--- a/py_src/fusion/utils.py
+++ b/py_src/fusion/utils.py
@@ -927,3 +927,60 @@ def requests_raise_for_status(response: requests.Response) -> None:
         response.reason = real_reason
     finally:
         response.raise_for_status()
+
+def validate_file_formats(fs_fusion: fsspec.AbstractFileSystem, path: str) -> None:
+    """
+    Validate file formats in the given folder and subfolders.
+    Raise an error if more than one raw (unrecognized) file is found.
+
+    Args:
+        fs (fsspec.AbstractFileSystem): Filesystem instance (local, S3, etc.)
+        folder_path (str): Root folder path to search
+
+    Raises:
+        ValueError: If more than one raw file is found.
+    """
+    if not fs_fusion.exists(path):
+        raise FileNotFoundError(f"The folder '{path}' does not exist.")
+
+    all_files = [f for f in fs_fusion.find(path) if fs_fusion.info(f)["type"] == "file"]
+    raw_files = [
+        f for f in all_files
+        if f.split(".")[-1].lower() not in RECOGNIZED_FORMATS
+    ]
+
+    if len(raw_files) > 1:
+        raise ValueError(
+            f"Multiple raw files detected in '{path}':\n"
+            f"{chr(10).join(raw_files)}\n\n"
+            f"Only one raw file is allowed. Supported formats are:\n"
+            f"{', '.join(RECOGNIZED_FORMATS)}"
+        )
+    
+def file_name_to_url(
+    file_name: str, dataset: str, catalog: str, is_download: bool = False
+) -> str:
+    """Construct a distribution URL using the constructed file name as the series member.
+
+    Args:
+        file_name (str): Flattened file name.
+        dataset (str): Dataset name.
+        catalog (str): Catalog name.
+        is_download (bool, optional): Whether the URL is for download. Defaults to False.
+
+    Returns:
+        str: Relative distribution URL string.
+    """
+    parts = file_name.rsplit(".", 1)
+
+    datasetseries = parts[0]  # Use the full base name (excluding extension) as the date
+    ext = (
+        "raw"
+        if len(parts) == 1 or parts[1].lower() not in RECOGNIZED_FORMATS
+        else parts[1].lower()
+    )
+
+    return "/".join(
+        distribution_to_url("", dataset, datasetseries, ext, catalog, is_download).split("/")[1:]
+    )
+

--- a/py_src/fusion/utils.py
+++ b/py_src/fusion/utils.py
@@ -672,54 +672,6 @@ def get_session(
     session.mount(mount_url, auth_handler)
     return session
 
-
-def validate_file_names(paths: list[str], fs_fusion: fsspec.AbstractFileSystem) -> list[bool]:
-    """Validate if the file name format adheres to the standard.
-
-    Args:
-        paths (list): List of file paths.
-        fs_fusion: Fusion filesystem.
-
-    Returns (list): List of booleans.
-
-    """
-    file_names = [i.split("/")[-1].split(".")[0] for i in paths]
-    validation = []
-    file_seg_cnt = 3
-    for i, f_n in enumerate(file_names):
-        tmp = f_n.split("__")
-        if len(tmp) == file_seg_cnt:
-            try:
-                val = tmp[1] in [i.split("/")[0] for i in fs_fusion.ls(tmp[1])]
-            except FileNotFoundError:
-                val = False
-            if not val:
-                validation.append(False)
-            else:
-                # check if dataset exists
-                try:
-                    val = tmp[0] in js.loads(fs_fusion.cat(f"{tmp[1]}/datasets/{tmp[0]}"))["identifier"]
-                except Exception:  # noqa: BLE001
-                    val = False
-                validation.append(val)
-        else:
-            validation.append(False)
-        if not validation[-1] and len(tmp) == file_seg_cnt:
-            logger.warning(
-                "You might not have access to the catalog %s or dataset %s. "
-                "Please check your permission on the platform.",
-                tmp[1],
-                tmp[0],
-            )
-        if not validation[-1] and len(tmp) != file_seg_cnt:
-            logger.warning(
-                f"The file in {paths[i]} has a non-compliant name and will not be processed. "
-                f"Please rename the file to dataset__catalog__yyyymmdd.format"
-            )
-
-    return validation
-
-
 def is_dataset_raw(paths: list[str], fs_fusion: fsspec.AbstractFileSystem) -> list[bool]:
     """Check if the files correspond to a raw dataset.
 

--- a/py_src/fusion/utils.py
+++ b/py_src/fusion/utils.py
@@ -672,6 +672,54 @@ def get_session(
     session.mount(mount_url, auth_handler)
     return session
 
+
+def validate_file_names(paths: list[str], fs_fusion: fsspec.AbstractFileSystem) -> list[bool]:
+    """Validate if the file name format adheres to the standard.
+
+    Args:
+        paths (list): List of file paths.
+        fs_fusion: Fusion filesystem.
+
+    Returns (list): List of booleans.
+
+    """
+    file_names = [i.split("/")[-1].split(".")[0] for i in paths]
+    validation = []
+    file_seg_cnt = 3
+    for i, f_n in enumerate(file_names):
+        tmp = f_n.split("__")
+        if len(tmp) == file_seg_cnt:
+            try:
+                val = tmp[1] in [i.split("/")[0] for i in fs_fusion.ls(tmp[1])]
+            except FileNotFoundError:
+                val = False
+            if not val:
+                validation.append(False)
+            else:
+                # check if dataset exists
+                try:
+                    val = tmp[0] in js.loads(fs_fusion.cat(f"{tmp[1]}/datasets/{tmp[0]}"))["identifier"]
+                except Exception:  # noqa: BLE001
+                    val = False
+                validation.append(val)
+        else:
+            validation.append(False)
+        if not validation[-1] and len(tmp) == file_seg_cnt:
+            logger.warning(
+                "You might not have access to the catalog %s or dataset %s. "
+                "Please check your permission on the platform.",
+                tmp[1],
+                tmp[0],
+            )
+        if not validation[-1] and len(tmp) != file_seg_cnt:
+            logger.warning(
+                f"The file in {paths[i]} has a non-compliant name and will not be processed. "
+                f"Please rename the file to dataset__catalog__yyyymmdd.format"
+            )
+
+    return validation
+
+
 def is_dataset_raw(paths: list[str], fs_fusion: fsspec.AbstractFileSystem) -> list[bool]:
     """Check if the files correspond to a raw dataset.
 

--- a/py_tests/test_fsync.py
+++ b/py_tests/test_fsync.py
@@ -456,11 +456,13 @@ def test_get_fusion_df_no_changes(mock_fs: mock.Mock) -> None:
 
 @patch("fusion.fs_sync._generate_sha256_token", return_value="47DEQpnsdfno3489HBFAQ=AF+sdjgbw3=")
 @patch("fusion.fs_sync.is_dataset_raw", return_value=[False])
+@patch("fusion.fs_sync.validate_file_names", return_value=[True])
 @patch("fusion.fs_sync.fsspec.filesystem")
 @patch("fusion.fs_sync.relpath", return_value="20241119/DATASET__catalog__20241119.csv")
 def test_get_local_state(
     mock_relpath: mock.Mock,  # noqa: ARG001
     mock_fs: mock.Mock,
+    mock_validate_file_names: mock.Mock,  # noqa: ARG001
     mock_is_dataset_raw: mock.Mock,  # noqa: ARG001
     mock_generate_sha256_token: mock.Mock,  # noqa: ARG001
 ) -> None:
@@ -510,11 +512,13 @@ def test_get_local_state(
 
 @patch("fusion.fs_sync._generate_sha256_token", return_value="47DEQpnsdfno3489HBFAQ=AF+sdjgbw3=")
 @patch("fusion.fs_sync.is_dataset_raw", return_value=[False])
+@patch("fusion.fs_sync.validate_file_names", return_value=[True])
 @patch("fusion.fs_sync.fsspec.filesystem")
 @patch("fusion.fs_sync.relpath", return_value="20241119/DATASET__catalog__20241119.csv")
 def test_get_local_state_mkdir(
     mock_relpath: mock.Mock,  # noqa: ARG001
     mock_fs: mock.Mock,
+    mock_validate_file_names: mock.Mock,  # noqa: ARG001
     mock_is_dataset_raw: mock.Mock,  # noqa: ARG001
     mock_generate_sha256_token: mock.Mock,  # noqa: ARG001
 ) -> None:
@@ -567,11 +571,13 @@ def test_get_local_state_mkdir(
 
 @patch("fusion.fs_sync._generate_sha256_token", return_value="47DEQpnsdfno3489HBFAQ=AF+sdjgbw3=")
 @patch("fusion.fs_sync.is_dataset_raw", return_value=[False])
+@patch("fusion.fs_sync.validate_file_names", return_value=[True])
 @patch("fusion.fs_sync.fsspec.filesystem")
 @patch("fusion.fs_sync.relpath", return_value="20241119/DATASET__catalog__20241119.csv")
 def test_get_local_state_with_local_state(
     mock_relpath: mock.Mock,  # noqa: ARG001
     mock_fs: mock.Mock,
+    mock_validate_file_names: mock.Mock,  # noqa: ARG001
     mock_is_dataset_raw: mock.Mock,  # noqa: ARG001
     mock_generate_sha256_token: mock.Mock,  # noqa: ARG001
 ) -> None:

--- a/py_tests/test_fsync.py
+++ b/py_tests/test_fsync.py
@@ -456,13 +456,11 @@ def test_get_fusion_df_no_changes(mock_fs: mock.Mock) -> None:
 
 @patch("fusion.fs_sync._generate_sha256_token", return_value="47DEQpnsdfno3489HBFAQ=AF+sdjgbw3=")
 @patch("fusion.fs_sync.is_dataset_raw", return_value=[False])
-@patch("fusion.fs_sync.validate_file_names", return_value=[True])
 @patch("fusion.fs_sync.fsspec.filesystem")
 @patch("fusion.fs_sync.relpath", return_value="20241119/DATASET__catalog__20241119.csv")
 def test_get_local_state(
     mock_relpath: mock.Mock,  # noqa: ARG001
     mock_fs: mock.Mock,
-    mock_validate_file_names: mock.Mock,  # noqa: ARG001
     mock_is_dataset_raw: mock.Mock,  # noqa: ARG001
     mock_generate_sha256_token: mock.Mock,  # noqa: ARG001
 ) -> None:
@@ -512,13 +510,11 @@ def test_get_local_state(
 
 @patch("fusion.fs_sync._generate_sha256_token", return_value="47DEQpnsdfno3489HBFAQ=AF+sdjgbw3=")
 @patch("fusion.fs_sync.is_dataset_raw", return_value=[False])
-@patch("fusion.fs_sync.validate_file_names", return_value=[True])
 @patch("fusion.fs_sync.fsspec.filesystem")
 @patch("fusion.fs_sync.relpath", return_value="20241119/DATASET__catalog__20241119.csv")
 def test_get_local_state_mkdir(
     mock_relpath: mock.Mock,  # noqa: ARG001
     mock_fs: mock.Mock,
-    mock_validate_file_names: mock.Mock,  # noqa: ARG001
     mock_is_dataset_raw: mock.Mock,  # noqa: ARG001
     mock_generate_sha256_token: mock.Mock,  # noqa: ARG001
 ) -> None:
@@ -571,13 +567,11 @@ def test_get_local_state_mkdir(
 
 @patch("fusion.fs_sync._generate_sha256_token", return_value="47DEQpnsdfno3489HBFAQ=AF+sdjgbw3=")
 @patch("fusion.fs_sync.is_dataset_raw", return_value=[False])
-@patch("fusion.fs_sync.validate_file_names", return_value=[True])
 @patch("fusion.fs_sync.fsspec.filesystem")
 @patch("fusion.fs_sync.relpath", return_value="20241119/DATASET__catalog__20241119.csv")
 def test_get_local_state_with_local_state(
     mock_relpath: mock.Mock,  # noqa: ARG001
     mock_fs: mock.Mock,
-    mock_validate_file_names: mock.Mock,  # noqa: ARG001
     mock_is_dataset_raw: mock.Mock,  # noqa: ARG001
     mock_generate_sha256_token: mock.Mock,  # noqa: ARG001
 ) -> None:

--- a/py_tests/test_utils.py
+++ b/py_tests/test_utils.py
@@ -36,8 +36,7 @@ from fusion.utils import (
     read_json,
     snake_to_camel,
     tidy_string,
-    upload_files,
-    validate_file_names,
+    upload_files,   
 )
 
 
@@ -622,50 +621,6 @@ def mock_fs_fusion() -> MagicMock:
     }.get(path, [])
     fs.cat.side_effect = lambda _: js.dumps({"identifier": "dataset1"})
     return fs
-
-
-def test_validate_correct_file_names(mock_fs_fusion: MagicMock) -> None:
-    paths = ["path/to/dataset1__catalog1__20230101.csv"]
-    expected = [True]
-    assert validate_file_names(paths, mock_fs_fusion) == expected
-
-
-def test_validate_incorrect_format_file_names(mock_fs_fusion: MagicMock) -> None:
-    paths = ["path/to/incorrectformatfile.csv"]
-    expected = [False]
-    assert validate_file_names(paths, mock_fs_fusion) == expected
-
-
-def test_validate_non_existing_catalog(mock_fs_fusion: MagicMock) -> None:
-    paths = ["path/to/dataset1__catalog3__20230101.csv"]
-    expected = [False]
-    assert validate_file_names(paths, mock_fs_fusion) == expected
-
-
-def test_validate_non_existing_dataset(mock_fs_fusion: MagicMock) -> None:
-    paths = ["path/to/dataset4__catalog1__20230101.csv"]
-    expected = [False]
-    assert validate_file_names(paths, mock_fs_fusion) == expected
-
-
-def test_validate_error_paths(mock_fs_fusion: MagicMock) -> None:
-    paths = ["path/to/catalog1__20230101.csv"]
-    expected = [False]
-    assert validate_file_names(paths, mock_fs_fusion) == expected
-
-
-def test_empty_input_list(mock_fs_fusion: MagicMock) -> None:
-    paths: list[str] = []
-    expected: list[bool] = []
-    assert validate_file_names(paths, mock_fs_fusion) == expected
-
-
-def test_filesystem_exceptions(mock_fs_fusion: MagicMock) -> None:
-    mock_fs_fusion.ls.side_effect = Exception("Failed to list directories")
-    paths = ["path/to/dataset1__catalog1__20230101.csv"]
-    with pytest.raises(Exception, match="Failed to list directories"):
-        validate_file_names(paths, mock_fs_fusion)
-
 
 def test_get_session(mocker: MockerFixture, credentials: FusionCredentials, fusion_obj: Fusion) -> None:
     session = get_session(credentials, fusion_obj.root_url)

--- a/py_tests/test_utils.py
+++ b/py_tests/test_utils.py
@@ -36,7 +36,8 @@ from fusion.utils import (
     read_json,
     snake_to_camel,
     tidy_string,
-    upload_files,   
+    upload_files,
+    validate_file_names,
 )
 
 
@@ -621,6 +622,50 @@ def mock_fs_fusion() -> MagicMock:
     }.get(path, [])
     fs.cat.side_effect = lambda _: js.dumps({"identifier": "dataset1"})
     return fs
+
+
+def test_validate_correct_file_names(mock_fs_fusion: MagicMock) -> None:
+    paths = ["path/to/dataset1__catalog1__20230101.csv"]
+    expected = [True]
+    assert validate_file_names(paths, mock_fs_fusion) == expected
+
+
+def test_validate_incorrect_format_file_names(mock_fs_fusion: MagicMock) -> None:
+    paths = ["path/to/incorrectformatfile.csv"]
+    expected = [False]
+    assert validate_file_names(paths, mock_fs_fusion) == expected
+
+
+def test_validate_non_existing_catalog(mock_fs_fusion: MagicMock) -> None:
+    paths = ["path/to/dataset1__catalog3__20230101.csv"]
+    expected = [False]
+    assert validate_file_names(paths, mock_fs_fusion) == expected
+
+
+def test_validate_non_existing_dataset(mock_fs_fusion: MagicMock) -> None:
+    paths = ["path/to/dataset4__catalog1__20230101.csv"]
+    expected = [False]
+    assert validate_file_names(paths, mock_fs_fusion) == expected
+
+
+def test_validate_error_paths(mock_fs_fusion: MagicMock) -> None:
+    paths = ["path/to/catalog1__20230101.csv"]
+    expected = [False]
+    assert validate_file_names(paths, mock_fs_fusion) == expected
+
+
+def test_empty_input_list(mock_fs_fusion: MagicMock) -> None:
+    paths: list[str] = []
+    expected: list[bool] = []
+    assert validate_file_names(paths, mock_fs_fusion) == expected
+
+
+def test_filesystem_exceptions(mock_fs_fusion: MagicMock) -> None:
+    mock_fs_fusion.ls.side_effect = Exception("Failed to list directories")
+    paths = ["path/to/dataset1__catalog1__20230101.csv"]
+    with pytest.raises(Exception, match="Failed to list directories"):
+        validate_file_names(paths, mock_fs_fusion)
+
 
 def test_get_session(mocker: MockerFixture, credentials: FusionCredentials, fusion_obj: Fusion) -> None:
     session = get_session(credentials, fusion_obj.root_url)

--- a/py_tests/test_utils.py
+++ b/py_tests/test_utils.py
@@ -624,48 +624,27 @@ def mock_fs_fusion() -> MagicMock:
     return fs
 
 
-def test_validate_correct_file_names(mock_fs_fusion: MagicMock) -> None:
+def test_validate_correct_file_names() -> None:
     paths = ["path/to/dataset1__catalog1__20230101.csv"]
     expected = [True]
-    assert validate_file_names(paths, mock_fs_fusion) == expected
+    assert validate_file_names(paths) == expected
 
 
-def test_validate_incorrect_format_file_names(mock_fs_fusion: MagicMock) -> None:
+def test_validate_incorrect_format_file_names() -> None:
     paths = ["path/to/incorrectformatfile.csv"]
     expected = [False]
-    assert validate_file_names(paths, mock_fs_fusion) == expected
+    assert validate_file_names(paths) == expected
 
-
-def test_validate_non_existing_catalog(mock_fs_fusion: MagicMock) -> None:
-    paths = ["path/to/dataset1__catalog3__20230101.csv"]
-    expected = [False]
-    assert validate_file_names(paths, mock_fs_fusion) == expected
-
-
-def test_validate_non_existing_dataset(mock_fs_fusion: MagicMock) -> None:
-    paths = ["path/to/dataset4__catalog1__20230101.csv"]
-    expected = [False]
-    assert validate_file_names(paths, mock_fs_fusion) == expected
-
-
-def test_validate_error_paths(mock_fs_fusion: MagicMock) -> None:
+def test_validate_error_paths() -> None:
     paths = ["path/to/catalog1__20230101.csv"]
     expected = [False]
-    assert validate_file_names(paths, mock_fs_fusion) == expected
+    assert validate_file_names(paths) == expected
 
 
-def test_empty_input_list(mock_fs_fusion: MagicMock) -> None:
+def test_empty_input_list() -> None:
     paths: list[str] = []
     expected: list[bool] = []
-    assert validate_file_names(paths, mock_fs_fusion) == expected
-
-
-def test_filesystem_exceptions(mock_fs_fusion: MagicMock) -> None:
-    mock_fs_fusion.ls.side_effect = Exception("Failed to list directories")
-    paths = ["path/to/dataset1__catalog1__20230101.csv"]
-    with pytest.raises(Exception, match="Failed to list directories"):
-        validate_file_names(paths, mock_fs_fusion)
-
+    assert validate_file_names(paths) == expected
 
 def test_get_session(mocker: MockerFixture, credentials: FusionCredentials, fusion_obj: Fusion) -> None:
     session = get_session(credentials, fusion_obj.root_url)

--- a/py_tests/test_utils.py
+++ b/py_tests/test_utils.py
@@ -942,7 +942,7 @@ def test_file_name_to_url(
 ) -> None:
 
     def mock_distribution_to_url(
-        root_url: str,
+        root_url: str, # noqa: ARG001
         dataset_arg: str,
         series: str,
         ext: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyfusion"
-version = "2.0.13"
+version = "2.0.14-dev0"
 
 homepage = "https://github.com/jpmorganchase/fusion"
 description = "JPMC Fusion Developer Tools"
@@ -243,7 +243,7 @@ exclude_lines = [
 
 
 [tool.bumpversion]
-current_version = "2.0.13"
+current_version = "2.0.14-dev0"
 parse = '(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<release>[a-z]+)(?P<candidate>\d+))?'
 serialize = [
     '{major}.{minor}.{patch}-{release}{candidate}',

--- a/uv.lock
+++ b/uv.lock
@@ -3230,7 +3230,7 @@ wheels = [
 
 [[package]]
 name = "pyfusion"
-version = "2.0.13"
+version = "2.0.14-dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
1) Removing list datasets and list catalog calls for validating the existence of dataset and catalog during upload files.
2) Enhance the bulk upload feature to enable file upload from a folder path which contain subfolders.