### PR TITLE
Feature/download fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "pyfusion"
-version = "2.0.15"
+version = "2.0.16-dev0"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyfusion"
-version = "2.0.15"
+version = "2.0.16-dev0"
 edition = "2021"
 
 

--- a/py_src/fusion/__init__.py
+++ b/py_src/fusion/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Fusion Devs"""
 __email__ = "fusion_developers@jpmorgan.com"
-__version__ = "2.0.15"
+__version__ = "2.0.16-dev0"
 
 from fusion._fusion import FusionCredentials
 from fusion.fs_sync import fsync

--- a/py_src/fusion/fusion.py
+++ b/py_src/fusion/fusion.py
@@ -812,12 +812,12 @@ class Fusion:
         """private function - Validate if dt_str is a valid date or date range using normalization logic.
         Accepts single date or range separated by ':'.
         """
-        if dt_str == "latest" or dt_str == "sample":
+        if dt_str in ("latest", "sample"):
             return True
         try:
             _ = normalise_dt_param_str(dt_str)
             return True
-        except Exception:
+        except ValueError:
             return False
         
     @staticmethod
@@ -907,7 +907,8 @@ class Fusion:
         if not required_series:
             raise APIResponseError(
                 ValueError(
-                    f"No data available for dataset {dataset} in catalog {catalog} for the given date/date range ({dt_str})."
+                    f"No data available for dataset {dataset} in catalog {catalog} "
+                    f"for the given date/date range ({dt_str})."
                 ),
                 status_code=404,
             )

--- a/py_src/fusion/fusion.py
+++ b/py_src/fusion/fusion.py
@@ -807,6 +807,18 @@ class Fusion:
 
         return tups
 
+    def _is_valid_date_range(dt_str: str) -> bool:
+        """Validate if dt_str is a valid date or date range using normalization logic.
+        Accepts single date or range separated by ':'.
+        """
+        if dt_str == "latest" or dt_str == "sample":
+            return True
+        try:
+            _ = normalise_dt_param_str(dt_str)
+            return True
+        except Exception:
+            return False
+
     def download(  # noqa: PLR0912, PLR0913
         self,
         dataset: str,
@@ -859,8 +871,6 @@ class Fusion:
                 status_code=401,
             )
 
-        valid_date_range = re.compile(r"^(\d{4}\d{2}\d{2})$|^((\d{4}\d{2}\d{2})?([:])(\d{4}\d{2}\d{2})?)$")
-
         # check that format is valid and if none, check if there is only one format available
         available_formats = list(self.list_datasetmembers_distributions(dataset, catalog)["format"].unique())
         if dataset_format and dataset_format not in available_formats:
@@ -877,7 +887,7 @@ class Fusion:
                     f"download. Available formats are {available_formats}."
                 )
 
-        if valid_date_range.match(dt_str) or dt_str == "latest":
+        if self._is_valid_date_range(dt_str):
             required_series = self._resolve_distro_tuples(dataset, dt_str, dataset_format, catalog)
         else:
             # sample data is limited to csv

--- a/py_src/fusion/utils.py
+++ b/py_src/fusion/utils.py
@@ -484,12 +484,12 @@ def _normalise_dt_param(dt: str | int | datetime | date) -> str:
     for candidate in (dt, dt_clean):
         try:
             ts = pd.to_datetime(candidate, errors="raise")
-            if ts.time() != datetime.min.time():
-                return ts.strftime("%Y-%m-%dT%H:%M:%S")
-            else:
-                return ts.strftime("%Y-%m-%d")
-        except Exception:
+        except (ValueError, TypeError):
             continue
+        if ts.time() != datetime.min.time():
+            return ts.strftime("%Y-%m-%dT%H:%M:%S")
+        else:
+            return ts.strftime("%Y-%m-%d")
 
     raise ValueError(f"{dt} is not in a recognised data format")
 

--- a/py_src/fusion/utils.py
+++ b/py_src/fusion/utils.py
@@ -469,6 +469,7 @@ def _normalise_dt_param(dt: str | int | datetime | date) -> str:
     Returns:
         str: A normalized date string.
     """
+    
     if isinstance(dt, (date, datetime)):
         return dt.strftime("%Y-%m-%d")
 
@@ -478,22 +479,17 @@ def _normalise_dt_param(dt: str | int | datetime | date) -> str:
     if not isinstance(dt, str):
         raise ValueError(f"{dt} is not in a recognised data format")
 
-    matches = DT_YYYY_MM_DD_RE.match(dt)
-    if matches:
-        yr = matches.group(1)
-        mth = matches.group(2).zfill(2)
-        day = matches.group(3).zfill(2)
-        return f"{yr}-{mth}-{day}"
+    dt_clean = re.sub(r"[ \-:T]", "", dt)
 
-    matches = DT_YYYYMMDD_RE.match(dt)
-
-    if matches:
-        return "-".join(matches.groups())
-
-    matches = DT_YYYYMMDDTHHMM_RE.match(dt)
-
-    if matches:
-        return "-".join(matches.groups())
+    for candidate in (dt, dt_clean):
+        try:
+            ts = pd.to_datetime(candidate, errors="raise")
+            if ts.time() != datetime.min.time():
+                return ts.strftime("%Y-%m-%dT%H:%M:%S")
+            else:
+                return ts.strftime("%Y-%m-%d")
+        except Exception:
+            continue
 
     raise ValueError(f"{dt} is not in a recognised data format")
 

--- a/py_tests/test_utils.py
+++ b/py_tests/test_utils.py
@@ -338,15 +338,25 @@ def test_normalise_dt_param_with_valid_string_format_3() -> None:
 
     dt = "20220101T1200"
     result = _normalise_dt_param(dt)
-    assert result == "2022-01-01-1200"
+    assert result == "2022-01-01T12:00:00"
 
 
 def test_normalise_dt_param_with_invalid_format() -> None:
     from fusion.utils import _normalise_dt_param
 
-    dt = "2022/01/01"
-    with pytest.raises(ValueError, match="is not in a recognised data format"):
-        _normalise_dt_param(dt)
+    invalid_dates = [
+        "2022-13-01",      # invalid month
+        "2022-01-32",      # invalid day
+        "20220101123456786",  # too many digits
+        "not-a-date",      # not a date at all
+        "",                # empty string
+    ]
+    for dt in invalid_dates:
+        with pytest.raises(
+            ValueError,
+            match="is not in a recognised data format|NaTType does not support time",
+        ):
+            _normalise_dt_param(dt)
 
 
 def test_normalise_dt_param_with_invalid_type() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyfusion"
-version = "2.0.15"
+version = "2.0.16-dev0"
 
 homepage = "https://github.com/jpmorganchase/fusion"
 description = "JPMC Fusion Developer Tools"
@@ -243,7 +243,7 @@ exclude_lines = [
 
 
 [tool.bumpversion]
-current_version = "2.0.15"
+current_version = "2.0.16-dev0"
 parse = '(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<release>[a-z]+)(?P<candidate>\d+))?'
 serialize = [
     '{major}.{minor}.{patch}-{release}{candidate}',

--- a/uv.lock
+++ b/uv.lock
@@ -3230,7 +3230,7 @@ wheels = [
 
 [[package]]
 name = "pyfusion"
-version = "2.0.15"
+version = "2.0.16-dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
*Made the changes in download method to download the seriesmembers between two timestamps (date, datetime, unix timestamp etc).
*convert a string (typically a date or identifier) into a safe filename by replacing any character that is not a digit, letter, or underscore with an underscore.  This helps prevent issues when saving files with names that might contain special or invalid characters.