### PR TITLE
Fix logger type check

### DIFF
--- a/py_src/fusion/fs_sync.py
+++ b/py_src/fusion/fs_sync.py
@@ -283,18 +283,18 @@ def fsync(  # noqa: PLR0912, PLR0913, PLR0915
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
-    if not any(isinstance(h, logging.FileHandler) for h in logger.handlers):
+    if not any(type(h) is logging.FileHandler for h in logger.handlers):
         file_handler = logging.FileHandler(filename="{}/{}".format(log_path, "fusion_fsync.log"))
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
 
-    if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+    if not any(type(h) is logging.StreamHandler for h in logger.handlers):
         stdout_handler = logging.StreamHandler(sys.stdout)
         stdout_handler.setFormatter(formatter)
         logger.addHandler(stdout_handler)
 
     if len(logger.handlers) > 1:
-        logger.handlers = [h for h in logger.handlers if not isinstance(h, logging.NullHandler)]
+        logger.handlers = [h for h in logger.handlers if type(h) is not logging.NullHandler]
 
     catalog = catalog if catalog else "common"
     datasets = datasets if datasets else []

--- a/py_src/fusion/fusion.py
+++ b/py_src/fusion/fusion.py
@@ -146,18 +146,18 @@ class Fusion:
             datefmt="%Y-%m-%d %H:%M:%S",
         )
 
-        if enable_logging and not any(isinstance(h, logging.FileHandler) for h in logger.handlers):
+        if enable_logging and not any(type(h) is logging.FileHandler for h in logger.handlers):
             file_handler = logging.FileHandler(filename=f"{log_path}/fusion_sdk.log")
             file_handler.setFormatter(formatter)
             logger.addHandler(file_handler)
 
-        if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+        if not any(type(h) is logging.StreamHandler for h in logger.handlers):
             stdout_handler = logging.StreamHandler(sys.stdout)
             stdout_handler.setFormatter(formatter)
             logger.addHandler(stdout_handler)
 
         if len(logger.handlers) > 1:
-            logger.handlers = [h for h in logger.handlers if not isinstance(h, logging.NullHandler)]
+            logger.handlers = [h for h in logger.handlers if type(h) is not logging.NullHandler]
 
         if isinstance(credentials, FusionCredentials):
             self.credentials = credentials

--- a/py_tests/test_fsync.py
+++ b/py_tests/test_fsync.py
@@ -909,9 +909,9 @@ def test_fsync_adds_handlers_when_none(
         log_path=".",
     )
 
-    assert any(isinstance(h, logging.StreamHandler) for h in logger.handlers)
-    assert any(isinstance(h, logging.FileHandler) for h in logger.handlers)
-    assert all(not isinstance(h, logging.NullHandler) for h in logger.handlers)
+    assert any(type(handler) is logging.StreamHandler for handler in logger.handlers)
+    assert any(type(handler) is logging.FileHandler for handler in logger.handlers)
+    assert all(type(handler) is not logging.NullHandler for handler in logger.handlers)
 
     fs_fusion.ca = fs_original
     logger.handlers.clear()

--- a/py_tests/test_fusion.py
+++ b/py_tests/test_fusion.py
@@ -3175,8 +3175,9 @@ def test_fusion_init_logging_to_specified_file(credentials: FusionCredentials) -
     Fusion(credentials=credentials, enable_logging=True)
 
     # Check that StreamHandler and FileHandler were added
-    assert any(isinstance(h, logging.StreamHandler) for h in logger.handlers)
-    assert any(isinstance(h, logging.FileHandler) for h in logger.handlers)
+    assert any(type(handler) is logging.StreamHandler for handler in logger.handlers)
+    assert any(type(handler) is logging.FileHandler for handler in logger.handlers)
+    assert not any(type(handler) is logging.NullHandler for handler in logger.handlers)
 
     # Confirm log file exists
     log_file = Path("fusion_sdk.log")
@@ -3194,8 +3195,9 @@ def test_fusion_init_logging_enabled_to_stdout_and_file(credentials: FusionCrede
     Fusion(credentials=credentials, enable_logging=True)
 
     # Ensure the logger is configured with both handlers
-    assert any(isinstance(handler, logging.StreamHandler) for handler in logger.handlers)
-    assert any(isinstance(handler, logging.FileHandler) for handler in logger.handlers)
+    assert any(type(handler) is logging.StreamHandler for handler in logger.handlers)
+    assert any(type(handler) is logging.FileHandler for handler in logger.handlers)
+    assert not any(type(handler) is logging.NullHandler for handler in logger.handlers)
 
     # Verify the log file exists
     log_file = Path("fusion_sdk.log")
@@ -3213,9 +3215,9 @@ def test_fusion_init_logging_disabled(credentials: FusionCredentials) -> None:
     Fusion(credentials=credentials, enable_logging=False)
 
     # No additional handlers should be added
-    assert any(isinstance(handler, logging.StreamHandler) for handler in logger.handlers)
-    assert all(not isinstance(handler, logging.FileHandler) for handler in logger.handlers)
-    assert not any(isinstance(handler, logging.NullHandler) for handler in logger.handlers)
+    assert any(type(handler) is logging.StreamHandler for handler in logger.handlers)
+    assert all(type(handler) is not logging.FileHandler for handler in logger.handlers)
+    assert not any(type(handler) is logging.NullHandler for handler in logger.handlers)
 
     # Clean up
     logger.handlers.clear()
@@ -3238,7 +3240,7 @@ def test_fusion_adds_streamhandler_when_no_handlers(credentials: FusionCredentia
     Fusion(credentials=credentials, enable_logging=False)
 
     assert len(logger.handlers) == 1
-    assert isinstance(logger.handlers[0], logging.StreamHandler)
+    assert type(logger.handlers[0]) is logging.StreamHandler
 
     logger.handlers.clear()
 


### PR DESCRIPTION
The fix ensures that handlers are now verified by their type rather than isinstance, which led to issues when handlers were subclasses.